### PR TITLE
Implemented GUI deletion of Category and LearningOutcome

### DIFF
--- a/src/main/java/learningOutcomes/Course.java
+++ b/src/main/java/learningOutcomes/Course.java
@@ -78,4 +78,13 @@ public class Course {
         }
         return true;
     }
+
+    public boolean hasOutcomeWithId(Integer id) {
+        for (LearningOutcome outcome: outcomes) {
+            if (outcome.getId() == id) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/learningOutcomes/controllers/CategoriesController.java
+++ b/src/main/java/learningOutcomes/controllers/CategoriesController.java
@@ -72,13 +72,19 @@ public class CategoriesController {
     }
 
     @RequestMapping(value="/{id}", method = RequestMethod.DELETE)
-    public Category deleteCategoryById(@PathVariable("id") Integer id, HttpServletResponse response) {
+    public Category deleteCategoryById(@PathVariable("id") Integer id, HttpServletResponse response) throws IOException {
         Optional<Category> category = categoryRepository.findById(id);
 
         if (category.isPresent()) {
             Category categoryToReturn = category.get();
-            categoryRepository.delete(category.get());
-            return categoryToReturn;
+            if (categoryToReturn.getSize() == 0) {
+                categoryRepository.delete(category.get());
+                return categoryToReturn;
+            }
+            else {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "cannot delete a category with learning outcomes, please remove all learning outcomes before deleting");
+                return null;
+            }
 
         } else {
             response.setStatus(HttpServletResponse.SC_NO_CONTENT);

--- a/src/main/java/learningOutcomes/controllers/LearningOutcomeController.java
+++ b/src/main/java/learningOutcomes/controllers/LearningOutcomeController.java
@@ -1,12 +1,14 @@
 package learningOutcomes.controllers;
 
 import learningOutcomes.Category;
+import learningOutcomes.Course;
 import learningOutcomes.LearningOutcome;
 import learningOutcomes.aspects.LearningOutcomeExistsValidated;
 import learningOutcomes.aspects.LearningOutcomeRequestValidated;
 import learningOutcomes.controllers.requestModels.LearningOutcomeRequest;
 import learningOutcomes.repositories.LearningOutcomeRepository;
 import learningOutcomes.repositories.CategoryRepository;
+import learningOutcomes.repositories.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import learningOutcomes.repositories.*;
 import org.springframework.web.bind.annotation.*;
@@ -19,11 +21,14 @@ import java.io.IOException;
 public class LearningOutcomeController {
 
     private CategoryRepository categoryRepository;
+    private CourseRepository courseRepository;
     private LearningOutcomeRepository learningOutcomeRepository;
 
+
     @Autowired
-    public LearningOutcomeController(CategoryRepository categoryRepository, LearningOutcomeRepository learningOutcomeRepository) {
+    public LearningOutcomeController(CategoryRepository categoryRepository, CourseRepository courseRepository, LearningOutcomeRepository learningOutcomeRepository) {
         this.categoryRepository = categoryRepository;
+        this.courseRepository = courseRepository;
         this.learningOutcomeRepository = learningOutcomeRepository;
     }
 
@@ -84,10 +89,18 @@ public class LearningOutcomeController {
         Optional<Category> category = categoryRepository.findById(categoryId);
 
         if (learningOutcome.isPresent() && category.isPresent()) {
+
             LearningOutcome learningOutcomeToReturn = learningOutcome.get();
             Category removeFrom = category.get();
             removeFrom.removeLearningOutcome(learningOutcomeToReturn);
             categoryRepository.save(removeFrom);
+            Iterable<Course> courses = courseRepository.findAll();
+            for (Course course: courses) {
+                if (course.hasOutcomeWithId(loId)) {
+                    course.removeLearningOutcome(learningOutcomeToReturn);
+                    courseRepository.save(course);
+                }
+            }
             learningOutcomeRepository.delete(learningOutcome.get());
             return learningOutcomeToReturn;
 

--- a/src/main/resources/static/categories.js
+++ b/src/main/resources/static/categories.js
@@ -1,5 +1,6 @@
 var EMPTY_HTML = '';
 var CATEGORIES_BASE_PATH = '/categories';
+var DELETE_CATEGORIES_SELECT_ID = '#deleteCategorySelect';
 
 var handleCreateCategoryFormSubmission = (e) => {
     e.preventDefault();
@@ -17,14 +18,48 @@ var handleCreateCategoryFormSubmission = (e) => {
         dataType:"json",
         success: (result) => {console.log(result);
             populateCategoriesForOutcomeForm();
+            populateDeleteCategoryForm();
         }
     });
 };
 
+var populateDeleteCategoryForm = () => {
+
+    $(DELETE_CATEGORIES_SELECT_ID).html(EMPTY_HTML);
+
+    $.get(CATEGORY_BASE_PATH, (categories) => {
+        categories.forEach((category) => {
+            $(DELETE_CATEGORIES_SELECT_ID).append('<option value="' + category.id + '">' + category.id + ': ' + category.name + '</option>');
+        });
+    });
+};
+
+var handleDeleteCategoryFormSubmission = (e) => {
+    e.preventDefault();
+
+    var id = $(DELETE_CATEGORIES_SELECT_ID).val();
+
+    if (id) {
+        $.ajax({
+            url: CATEGORY_BASE_PATH + '/' + id,
+            type: 'DELETE',
+            contentType: 'application/json',
+            dataType: "json",
+            success: () => {
+                populateDeleteCategoryForm();
+                populateCategoriesForOutcomeForm();
+            },
+            error: (errorResult) => {
+                alert("Could not delete category: " + errorResult.responseJSON.message);
+            }
+        });
+    }
+};
 
 var setUp = () => {
-
+    populateDeleteCategoryForm();
     $('#categoryForm').submit(handleCreateCategoryFormSubmission);
+    $('#deleteCategoryForm').submit(handleDeleteCategoryFormSubmission);
 };
 
 

--- a/src/main/resources/static/learningOutcomes.js
+++ b/src/main/resources/static/learningOutcomes.js
@@ -41,17 +41,11 @@ var handleCreateOutcomeFormSubmission = (e) => {
 
     var id;
     var inputs = $('form#outcomeForm :input').serializeArray().forEach((input) => {
-        if (input.name === 'name') {
-            outcomeData[input.name] = input.value;
-        } else if (input.name === 'category') {
-            id = input.value;
-            outcomeData.category = id;
-        }
-
+        outcomeData[input.name] = input.value;
     });
 
     $.ajax({
-        url:'/categories/' + id + '/learningOutcomes',
+        url:'/categories/' + outcomeData.category + '/learningOutcomes',
         type:'POST',
         data: JSON.stringify(outcomeData),
         contentType:'application/json',

--- a/src/main/resources/static/learningOutcomes.js
+++ b/src/main/resources/static/learningOutcomes.js
@@ -2,6 +2,8 @@ var EMPTY_HTML = '';
 var ALL_LEARNING_OUTCOMES_ID = '#allLearningOutcomes';
 var CREATE_OUTCOME_CATEGORY_SELECT_ID = '#categorySelect';
 var CATEGORY_BASE_PATH = '/categories';
+var OUTCOME_BASE_PATH = '/learningOutcomes';
+var DELETE_OUTCOMES_SELECT_ID = '#deleteOutcomeSelect';
 
 var clearLearningOutcomes = () => {
     $(ALL_LEARNING_OUTCOMES_ID).html(EMPTY_HTML);
@@ -41,7 +43,7 @@ var handleCreateOutcomeFormSubmission = (e) => {
     var inputs = $('form#outcomeForm :input').serializeArray().forEach((input) => {
         if (input.name === 'name') {
             outcomeData[input.name] = input.value;
-        } else if (input.name === 'courses') {
+        } else if (input.name === 'category') {
             id = input.value;
             outcomeData.category = id;
         }
@@ -56,6 +58,7 @@ var handleCreateOutcomeFormSubmission = (e) => {
         dataType:"json",
         success: () => {
             displayLearningOutcomeList();
+            populateDeleteOutcomeForm();
             populateOutcomesForCourseForm();
         }
     });
@@ -74,15 +77,48 @@ var populateCategoriesForOutcomeForm = () => {
     });
 };
 
+var populateDeleteOutcomeForm = () => {
 
+    $(DELETE_OUTCOMES_SELECT_ID).html(EMPTY_HTML);
 
+    $.get(CATEGORY_BASE_PATH, (categories) => {
+        categories.forEach((category) => {
+            category.learningOutcomes.forEach((outcome) => {
+                $(DELETE_OUTCOMES_SELECT_ID).append('<option value="' + outcome.category + ' ' + outcome.id + '">' + outcome.id + ': ' + outcome.name + '</option>');
+            });
+        });
+    });
+};
 
+var handleDeleteOutcomeFormSubmission = (e) => {
+    e.preventDefault();
+
+    var vals = $(DELETE_OUTCOMES_SELECT_ID).val();
+
+    if (vals) {
+        var ids = vals.split(" ");
+        $.ajax({
+            url: CATEGORY_BASE_PATH + '/' + ids[0] + OUTCOME_BASE_PATH + '/' + ids[1],
+            type: 'DELETE',
+            contentType: 'application/json',
+            dataType: "json",
+            success: () => {
+                displayLearningOutcomeList();
+                populateDeleteOutcomeForm();
+                displayCourseList();
+                populateOutcomesForCourseForm();
+            }
+        });
+    }
+};
 
 
 var setUp = () => {
     displayLearningOutcomeList();
     populateCategoriesForOutcomeForm();
+    populateDeleteOutcomeForm();
     $('#outcomeForm').submit(handleCreateOutcomeFormSubmission);
+    $('#deleteOutcomeForm').submit(handleDeleteOutcomeFormSubmission);
 };
 
 

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -50,15 +50,27 @@
 </div>
 
 <div id="delete" class="hidden">
-    <h1>Delete Program</h1>
-    <form id="deleteProgramForm" action="#">
-        <p>Program To Delete: <select id="deleteProgramSelect" name="id"></select></p>
+    <h1>Delete Category</h1>
+    <form id="deleteCategoryForm" action="#">
+        <p>Category To Delete: <select id="deleteCategorySelect" name="id"></select></p>
+        <p><input type="submit" value="Submit"/> <input type="reset" value="Reset"/></p>
+    </form>
+
+    <h1>Delete Learning Outcome</h1>
+    <form id="deleteOutcomeForm" action="#">
+        <p>Learning Outcome To Delete: <select id="deleteOutcomeSelect" name="id"></select></p>
         <p><input type="submit" value="Submit"/> <input type="reset" value="Reset"/></p>
     </form>
 
     <h1>Delete Course</h1>
     <form id="deleteCourseForm" action="#">
         <p>Course To Delete: <select id="deleteCourseSelect" name="id"></select></p>
+        <p><input type="submit" value="Submit"/> <input type="reset" value="Reset"/></p>
+    </form>
+
+    <h1>Delete Program</h1>
+    <form id="deleteProgramForm" action="#">
+        <p>Program To Delete: <select id="deleteProgramSelect" name="id"></select></p>
         <p><input type="submit" value="Submit"/> <input type="reset" value="Reset"/></p>
     </form>
 </div>

--- a/src/test/java/learningOutcomes/controllers/CategoriesControllerTest.java
+++ b/src/test/java/learningOutcomes/controllers/CategoriesControllerTest.java
@@ -59,6 +59,22 @@ public class CategoriesControllerTest {
         return categoryId;
     }
 
+    private String createEmptyCategory() throws Exception {
+        MvcResult postResult = mockMvc.perform(
+                post(CATEGORY_BASE_PATH)
+                        .contentType("application/json")
+                        .content("{\"name\": \"" + NAME + "\", \"learningOutcomes\": []}")
+        )
+                .andDo(print())
+                .andReturn();
+
+        JsonParser parser = new JsonParser();
+        JsonObject jsonObject = parser.parse(postResult.getResponse().getContentAsString()).getAsJsonObject();
+        String categoryId = jsonObject.get("id").getAsString();
+
+        return categoryId;
+    }
+
     @Before
     public void setUp() {
         outcome = new LearningOutcome();
@@ -189,7 +205,7 @@ public class CategoriesControllerTest {
     @Test
     public void testDeleteCategoryById() throws Exception {
 
-        String categoryId = createCategory();
+        String categoryId = createEmptyCategory();
 
         mockMvc.perform(
                 delete(CATEGORY_BASE_PATH + "/" + categoryId)
@@ -201,10 +217,7 @@ public class CategoriesControllerTest {
                 .andExpect(jsonPath("$.name").value(NAME))
                 .andExpect(jsonPath("$.learningOutcomes").exists())
                 .andExpect(jsonPath("$.learningOutcomes").isArray())
-                .andExpect(jsonPath("$.learningOutcomes").isNotEmpty())
-                .andExpect(jsonPath("$.learningOutcomes[0].id").value(outcome.getId()));
-
-        assertTrue(!learningOutcomeRepository.findById(outcome.getId()).isPresent());
+                .andExpect(jsonPath("$.learningOutcomes").isEmpty());
     }
 
     @Test


### PR DESCRIPTION
# Contents of Pull Request
* https://github.com/gsteelex/sysc4806_redSquadron_project/projects/1#card-8554954
* Add forms for deletion of Category and LearningOutcome objects
* Stop the deletion request from GUI of Categories and LearningOutcomes if none are selected
* Display error alert if attempting to delete a Category that contains any LearningOutcomes
* Minor updates to CategoriesController and associated tests to reflect new requirements

# Not in this Pull Request
* EA or UML diagram updates, the UML update will be done later on a separate branch.

# Risks
* There are no expected risks

# Checklist
[✔️] Tried new functionality on a running local server
[✔️] Verified branch build succeeded in TravisCI
[✔️] Self documenting JavaScript function names and comments where required